### PR TITLE
Update international example

### DIFF
--- a/examples/International/International.ino
+++ b/examples/International/International.ino
@@ -112,8 +112,7 @@ keyboard.setNoRepeat( 1 );
 
 void loop()
 {
-code = keyboard.available();
-if( code > 0 )
+if( keyboard.available() )
   {
   code = keyboard.read();
   Serial.print( "Value " );


### PR DESCRIPTION
Setting the return value of keyboard.available() equal to "code" seemed inconsistent with examples in the PS2KeyAdvanced library, and was rather confusing since (if I understand correctly), available() returns the # of key presses in the buffer, and not a code for a specific key.  

Recommend using the if( keyboard.available( ) ) construct instead.  Just my 2 cents.  Great libraries!  Thank you!